### PR TITLE
Added Delegate for setPrimaryItems

### DIFF
--- a/src/com/imbryk/viewPager/LoopPagerAdapterWrapper.java
+++ b/src/com/imbryk/viewPager/LoopPagerAdapterWrapper.java
@@ -149,6 +149,11 @@ public class LoopPagerAdapterWrapper extends PagerAdapter {
         mAdapter.startUpdate(container);
     }
 
+    @Override
+    public void setPrimaryItem(ViewGroup container, int position, Object object) {
+        mAdapter.setPrimaryItem(container, position, object);
+    }
+
     /*
      * End delegation
      */


### PR DESCRIPTION
Fragment with a FragmentPagerAdapter will now have setUserVisibleHint
called when shown.

Based on this StackOverflowQuestion:
http://stackoverflow.com/questions/10024739/how-to-determine-when-fragment-becomes-visible-in-viewpager

The PagerAdapter should forward and delegate the setPrimaryItem to allow for FragmentPagerAdapter to call the setUserVisibleHint methods to true.
