### PR TITLE
Allow empty adapter

### DIFF
--- a/src/com/imbryk/viewPager/LoopPagerAdapterWrapper.java
+++ b/src/com/imbryk/viewPager/LoopPagerAdapterWrapper.java
@@ -78,7 +78,7 @@ public class LoopPagerAdapterWrapper extends PagerAdapter {
 
     @Override
     public int getCount() {
-        return mAdapter.getCount() + 2;
+        return mAdapter.getCount() > 0 ? mAdapter.getCount() + 2 : 0;
     }
 
     public int getRealCount() {


### PR DESCRIPTION
Make wrapping adapter empty when the wrapped adapter is empty. Before when the wrapped adapter returned 0 from `getCount()`, signaling that it doesn't want to create any pages, the wrapping adapter returned 2. Because of that view pager could still call `instantiateItem()`. In my case my wrapped adapter wasn't ready at all to run `instantiateItem()` while `getCount()` returned 0 and it crashed. Thanks to this change view pager is blank until I add some data, which is exactly what I expect.
